### PR TITLE
Fix compilation on GCC

### DIFF
--- a/src/gf25519.c
+++ b/src/gf25519.c
@@ -371,7 +371,7 @@ gf_mul_inline(gf *d, const gf *a, const gf *b)
 		   to fold. This is extra work right now, but removes
 		   an extra dependency later on. */
 		"shld	$1, %%r11, %%r15\n\t"
-		"andq	global_m63, %%r11\n\t"
+		"andq	%6, %%r11\n\t"
 		"imulq	$(" ST(MQ) "), %%r15, %%r15\n\t"
 		"addq	%%r15, %%r8\n\t"
 		"adcq	%%rsi, %%r9\n\t"
@@ -401,7 +401,7 @@ gf_mul_inline(gf *d, const gf *a, const gf *b)
 		"movq	%%r11, 24(%0)\n\t"
 
 		: "=D" (d), "=S" (a), "=c" (b)
-		: "0" (d), "1" (a), "2" (b)
+		: "0" (d), "1" (a), "2" (b), "m"(global_m63)
 		: "cc", "memory", "rax", "rbx", "rdx", "r8", "r9",
 		  "r10", "r11", "r12", "r13", "r14", "r15"
 	);
@@ -520,7 +520,7 @@ gf_sqr_inline(gf *d, const gf *a)
 		   to fold. This is extra work right now, but removes
 		   an extra dependency later on. */
 		"shld	$1, %%r11, %%r15\n\t"
-		"andq	global_m63, %%r11\n\t"
+		"andq	%4, %%r11\n\t"
 		"imulq	$(" ST(MQ) "), %%r15, %%r15\n\t"
 		"addq	%%r15, %%r8\n\t"
 		"adcq	%%rsi, %%r9\n\t"
@@ -550,7 +550,7 @@ gf_sqr_inline(gf *d, const gf *a)
 		"movq	%%r11, 24(%0)\n\t"
 
 		: "=D" (d), "=S" (a)
-		: "0" (d), "1" (a)
+		: "0" (d), "1" (a), "m"(global_m63)
 		: "cc", "memory", "rax", "rbx", "rcx", "rdx", "r8", "r9",
 		  "r10", "r11", "r12", "r13", "r14", "r15"
 	);
@@ -673,7 +673,7 @@ gf_sqr_x_inline(gf *d, const gf *a, long num)
 		   to fold. This is extra work right now, but removes
 		   an extra dependency later on. */
 		"shld	$1, %%rbp, %%r15\n\t"
-		"andq	global_m63, %%rbp\n\t"
+		"andq	%6, %%rbp\n\t"
 		"imulq	$(" ST(MQ) "), %%r15, %%r15\n\t"
 		"addq	%%r15, %%rax\n\t"
 		"adcq	%%r10, %%rbx\n\t"
@@ -698,7 +698,7 @@ gf_sqr_x_inline(gf *d, const gf *a, long num)
 		"movq	%%rbp, 24(%%rdi)\n\t"
 
 		: "=D" (d), "=S" (a), "=d" (num)
-		: "0" (d), "1" (a), "2" (num)
+		: "0" (d), "1" (a), "2" (num), "m"(global_m63)
 		: "cc", "memory", "rax", "rbx", "rcx", "rbp", "r8", "r9",
 		  "r10", "r11", "r12", "r13", "r14", "r15"
 	);

--- a/src/gf25519.c
+++ b/src/gf25519.c
@@ -273,7 +273,8 @@ __attribute__((always_inline))
 static inline void
 gf_mul_inline(gf *d, const gf *a, const gf *b)
 {
-	__asm__ (
+
+	__asm__ volatile (
 		/*
 		 * We compute the 512-bit result into r8..r15. Carry
 		 * word is in rax. Multiplier word is in rdx (since that's
@@ -421,7 +422,7 @@ __attribute__((always_inline))
 static inline void
 gf_sqr_inline(gf *d, const gf *a)
 {
-	__asm__ (
+	__asm__ volatile (
 		/*
 		 * We compute the 512-bit result into r8..r15. Carry
 		 * word is in rax. Multiplier word is in rdx (since that's
@@ -570,7 +571,7 @@ __attribute__((always_inline))
 static void
 gf_sqr_x_inline(gf *d, const gf *a, long num)
 {
-	__asm__ (
+	__asm__ volatile (
 		/*
 		 * Load a0..a3 into rax:rbx:rcx:rbp
 		 * Then reuse esi as loop counter.
@@ -1316,7 +1317,7 @@ gf_inv(gf *d, const gf *y)
 		 * total on a Coffee Lake core.
 		 */
 
-		__asm__ (
+		__asm__ volatile (
 			/*
 			 * f0 = 1
 			 * g0 = 0
@@ -1400,7 +1401,7 @@ gf_inv(gf *d, const gf *y)
 	 * be zero, in which case a = 0 and v = 0 throughout, which is
 	 * the expected result.
 	 */
-	__asm__ (
+	__asm__ volatile  (
 		/* Set f0, g0, f1 and g1. */
 		"movl	$1, %%eax\n\t"
 		"xorl	%%ebx, %%ebx\n\t"

--- a/src/test_gf25519.c
+++ b/src/test_gf25519.c
@@ -5,6 +5,15 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifndef __clang__
+static __inline__ unsigned long long __rdtsc(void)
+{
+    unsigned hi, lo;
+    __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+    return ( (unsigned long long)lo)|( ((unsigned long long)hi)<<32 );
+}
+#endif
+
 /*
  * We try to bind to a specific CPU so that measures are easier to
  * reproduce.


### PR DESCRIPTION
I initially missed the Makefile, and the usage of `clang`, so I came up with these changes to make it work on GCC 9.3.0 on Linux.

GCC is a lot slower, though.